### PR TITLE
Script to run validations from command line + docs

### DIFF
--- a/implementations/validator/README.md
+++ b/implementations/validator/README.md
@@ -1,0 +1,56 @@
+# IIIF Validator
+
+This validator supports the same validations that are available on the 
+[IIIF](http://iiif.io/) website at <http://iiif.io/api/image/validator/>.
+
+## Running the validator locally
+
+Dependencies:
+
+  * lxml
+  * bottle
+  * python-magic (which requires libmagic)
+  * PIL (via Pillow)
+
+On a mac one can do:
+
+```
+brew install libmagic
+pip install lxml bottle python-magic pillow
+```
+
+Then for an image served at `http://localhost:8000/prefix/image_id`
+tha validator can be run with:
+
+```
+./validate.py -s localhost:8000 -p prefix -i image_id --version=2.0 -v
+```
+ 
+or similar to validate server with the test image. Use `./validate -h` for 
+parameter details.
+
+## Using `validate.sh` with Travis CI
+
+To install dependencies for this code the following lines must 
+be present in the `install:` section of `.travis.yml`:
+
+```
+install:
+  ...
+  - pip install Pillow
+  - sudo apt-get update
+  - sudo apt-get install libmagic-dev
+  - pip install bottle python-magic lxml
+```
+
+and then a single validation can be added to the commands under
+the `script:` section of     `.travis.yml`:
+
+```
+script:
+  ...
+  - ./validate.py -s localhost:8000 -p prefix -i image_id1 --version=1.1 --level 1 --quiet
+```
+
+The `validate.py` script returns 0 exit code on success, non-zero on failure,
+in order to work easily with Travis CI.

--- a/implementations/validator/validate.py
+++ b/implementations/validator/validate.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""
+Run validator code from command line
+
+Wrapper around validator.py for use in local manual and continuous 
+integration tests of IIIF servers. Command line options specify
+parameters of the server, the API version to be tested and the 
+expected compliance level. Exit code is zero for success, non-zero 
+otherwise (number of failed tests).
+"""
+
+#kuldge to fix mode of validator.py
+import os
+os.environ['VALIDATOR_AS_MODULE']='1'
+from validator import ValidationInfo,TestSuite,ImageAPI
+import logging
+import optparse
+import sys
+
+# Options and arguments
+p = optparse.OptionParser(description='IIIF Command Line Validator',
+                          usage='usage: %prog -s SERVER -p PREFIX -i IDENTIFIER [options]  (-h for help)')
+p.add_option('--identifier','-i', action='store',
+             help="identifier to run tests for")
+p.add_option('--server','-s', action='store', default='localhost:8000',
+             help="server name of IIIF service, including port if not port 80 (default localhost:8000)")
+p.add_option('--prefix','-p', action='store', default='',
+             help="prefix of IIIF service on server (default none)")
+p.add_option('--scheme', action='store', default='http',
+             help="scheme (http or https, default http)")
+p.add_option('--auth','-a', action='store', default='',
+             help="auth info for service (default none)")
+p.add_option('--version', action='store', default='2.0',
+             help="IIIF API version to test for (default 2.0)")
+p.add_option('--level', action='store', type='int', default=1,
+             help="compliance level to test (default 1)")
+p.add_option('--verbose', '-v', action='store_true',
+             help="be verbose")
+p.add_option('--quiet','-q', action='store_true',
+             help="minimal output only for errors")
+(opt, args) = p.parse_args()
+
+# Logging/output
+level = (logging.INFO if opt.verbose else (logging.ERROR if opt.quiet else logging.WARNING))
+logging.basicConfig(level=level,format='%(message)s')
+
+# Sanity check
+if (not opt.identifier):
+    logging.error("No identifier specified, aborting (-h for help)") 
+    exit(99)
+
+# Run as one shot set of tests with output to stdout
+info2 = ValidationInfo()
+tests = TestSuite(info2).list_tests(opt.version)
+n = 0
+bad = 0
+for testname in tests:
+    if (tests[testname]['level']>opt.level):
+        continue
+    n += 1
+    test_str = ("[%d] test %s" % (n,testname))
+    try:
+        info = ValidationInfo()
+        testSuite = TestSuite(info) 
+        result = ImageAPI(opt.identifier, opt.server, opt.prefix, opt.scheme, opt.auth, opt.version, 
+                          debug=False)
+        testSuite.run_test(testname, result)
+        if result.exception:
+            e = result.exception
+            bad += 1
+            logging.error("%s FAIL"%test_str)
+            logging.error("  url: %s\n  got: %s\n  expected: %s\n  type: %s"%(result.urls,e.got,e.expected,e.type))
+        else:
+            logging.warning("%s PASS"%test_str)
+            logging.info("  url: %s\n  tests: %s\n"%(result.urls,result.tests))
+    except Exception as e:
+        bad += 1
+        logging.error("%s FAIL"%test_str)
+        logging.error("  exception: %s\n"%(str(e)))
+logging.warning("Done (%d tests, %d failures)" % (n,bad))
+exit(bad)

--- a/implementations/validator/validator.py
+++ b/implementations/validator/validator.py
@@ -18,6 +18,7 @@ import json
 import StringIO
 import sys
 import random
+import os
 
 try:
     from PIL import Image, ImageDraw
@@ -125,9 +126,10 @@ class TestSuite(object):
  
 class ImageAPI(object):
 
-    def __init__(self, identifier, server, prefix="", scheme="http", auth="", version="2.0"):
+    def __init__(self, identifier, server, prefix="", scheme="http", auth="", version="2.0", debug=True):
 
         self.iiifNS = "{http://library.stanford.edu/iiif/image-api/ns/}"
+        self.debug = debug
 
         self.scheme = scheme
         self.server = server
@@ -297,7 +299,8 @@ class ImageAPI(object):
         scheme = params.get('scheme', self.scheme)
         server = params.get('server', self.server)
         url = "%s://%s/%s" % (scheme, server, url)
-        print url
+        if (self.debug):
+            print url
         return url
 
     def make_image(self, data):
@@ -340,9 +343,10 @@ class ImageAPI(object):
 
 class Validator(object):
 
-    def __init__(self):
-        sys.stderr.write('init on Validator');
-        sys.stderr.flush()
+    def __init__(self,debug=True):
+        if (debug):
+            sys.stderr.write('init on Validator\n')
+            sys.stderr.flush()
 
     def handle_test(self, testname):
 
@@ -357,7 +361,7 @@ class Validator(object):
             return "No such test: %s" % testname
 
         server = request.query.get('server', '')
-        server = server.strip();
+        server = server.strip()
         if server.startswith('https://'):
             scheme = 'https'
             server = server.replace('https://', '')
@@ -461,7 +465,7 @@ class Validator(object):
 
 
 def apache():
-    v = Validator();
+    v = Validator()
     return v.get_bottle_app()
 
 def main():
@@ -471,5 +475,5 @@ def main():
 
 if __name__ == "__main__":
     main()
-else:
+elif (not os.getenv('VALIDATOR_AS_MODULE')):
     application = apache()


### PR DESCRIPTION
The script `validate.py` runs validations from the command line (no significant changes required for refactored code - hurrah). There are a couple of tweaks to reporting and intialization in `validator.py` so that it will work well with the command line script. These _should not_ affect the existing function of `validator.py`... Not sure these are quite ready to go in because we could perhaps do something tidier but that might mean larger changes or changes that would affect the current function, doing a pull request because that seems the easiest way to package for review.
