### PR TITLE
Greut unittest - Add test case for the CORS header issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /.vagrant
 /.cache
+/.eggs
 /build
 /dist
 /iiif_validator.egg-info

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.4"
+  - "3.5"
 install:
   - python setup.py install
 script:

--- a/iiif_validator/tests/cors.py
+++ b/iiif_validator/tests/cors.py
@@ -10,8 +10,9 @@ class Test_Cors(BaseTest):
     def run(self, result):
         info = result.get_info();
         cors = ''
-        for k,v in result.last_headers:
+        for k,v in result.last_headers.items():
             if k.lower() == 'access-control-allow-origin':
                 cors = v
+                break
         self.validationInfo.check('CORS', cors, '*', result)
         return result

--- a/setup.py
+++ b/setup.py
@@ -41,4 +41,7 @@ setup(
         "lxml"
     ],
     test_suite="tests",
+    tests_require=[
+        "mock"
+    ]
 )

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,9 +1,9 @@
 """Test code for validator."""
+import mock
 import unittest
-import re
 
 from iiif_validator.validator import ValidationInfo, TestSuite, ImageAPI, Validator
-
+from iiif_validator.tests.cors import Test_Cors
 
 class TestAll(unittest.TestCase):
     """Tests."""
@@ -28,3 +28,15 @@ class TestAll(unittest.TestCase):
         """Validator class initialization."""
         v = Validator()
         self.assertTrue(hasattr(v, 'handle_test'))
+
+    def test05_cors(self):
+        """Test suite CORS."""
+        m = mock.Mock()
+        t = Test_Cors(m)
+
+        r = mock.Mock()
+        setattr(r, 'last_headers', {
+            'Access-Control-Allow-Origin': ':-)'
+        })
+        t.run(r)
+        m.check.assert_called_with('CORS', ':-)', '*', r)


### PR DESCRIPTION
Resolves merge conflicts and replaces / closes #46

Note `iteritems()` changed to `items()` for py3, also added py 3.4 and 3.5 tests to travis