### PR TITLE
Adds deployment stuff for AWS

### DIFF
--- a/.ebextensions/packages.config
+++ b/.ebextensions/packages.config
@@ -1,0 +1,4 @@
+packages:
+  yum:
+    libxml2-devel: []
+    libxslt-devel: []

--- a/.ebextensions/pip.config
+++ b/.ebextensions/pip.config
@@ -1,0 +1,3 @@
+commands:
+  update_pip:
+    command: "/opt/python/run/venv/bin/pip install --upgrade pip"

--- a/.ebextensions/wsgi.config
+++ b/.ebextensions/wsgi.config
@@ -1,0 +1,3 @@
+option_settings:
+  aws:elasticbeanstalk:container:python:
+    WSGIPath: iiif-validator.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,18 @@ install:
   - pip install tox tox-travis
 script:
   - tox
+before_deploy:
+  - mkdir build; zip -q -r build/image-validator.zip .
+deploy:
+  provider: s3
+  access_key_id:
+    secure: NBYUTQ7iS+y8KjeHdpwooU327ztNl88YknqBoC6QUacSaTGZ/Ym1nqZR3T0W8L+hPf/ATPf68MPBjJ+u/Mk7eG1uor+4rcqgp3zfwoLNCmqzVWqOcHGQiSDU/C7KzAuo7RIO0jQh7fvWeS/u3XOTby8+uboA30OywF+aKaUHEfQ=
+  secret_access_key:
+    secure: KyIFa8ASKaftvdfKiELkyAYEaHKGCNyTSVY4WjEv3Knu/R3R5/CIKtCo2iy6Q5KIO8m+zCVai34k+kG7oIbURvDy+TeDaYaOJgqqVUURQ149PyCG0jYMs2RXZKMkwWOZz5zL0ZbHu0v486LL6yFmQHQTgWSa+Vg79sUX8qYDLqQ=
+  bucket: iiif-deployment-artifacts
+  region: us-west-2
+  local_dir: build
+  skip_cleanup: true
+  upload-dir: image-validator/${TRAVIS_BRANCH}
+  on:
+    python: '3.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+lxml
+bottle
+python-magic
+pillow


### PR DESCRIPTION
These changes are a portion of the work needed to simplify the splitting of repos for iiif.io:
 - the `.ebextensions` stuff is to be able to deploy this as a standalone service in AWS in ElasticBeanstalk
 - the `requirements.txt` is needed for the ElasticBeanstalk deploy
 - the `.travis.yml` stuff ships a copy of the code to S3 so we can auto-deploy this to said ElasticBeanstalk environment