### PR TITLE
Removed PNG requirement for quality_bitonal test

### DIFF
--- a/iiif_validator/tests/quality_bitonal.py
+++ b/iiif_validator/tests/quality_bitonal.py
@@ -9,7 +9,7 @@ class Test_Quality_Bitonal(BaseTest):
 
     def run(self, result):
         try:
-            params = {'quality': 'bitonal', 'format':'png'}
+            params = {'quality': 'bitonal'}
             img = result.get_image(params)
 
             cols = img.getcolors()


### PR DESCRIPTION
Bitonal output can be in any supported image format, so the quality_bitonal test shouldn't insist on using PNG