### PR TITLE
Fixing redirect check

### DIFF
--- a/iiif_validator/tests/baseurl_redirect.py
+++ b/iiif_validator/tests/baseurl_redirect.py
@@ -2,9 +2,11 @@ from .test import BaseTest, ValidatorError
 try:
     # python3
     from urllib.request import Request, urlopen, HTTPError
+    print ('Importing 3')
 except ImportError:
     # fall back to python2
     from urllib2 import Request, urlopen, HTTPError
+    print ('Importing 2')
 
 
 class Test_Baseurl_Redirect(BaseTest):
@@ -17,16 +19,24 @@ class Test_Baseurl_Redirect(BaseTest):
     def run(self, result):
         url = result.make_info_url()
         url = url.replace('/info.json', '')
+        newurl = ''
         try:
             r = Request(url)
             wh = urlopen(r)
             img = wh.read()   
             wh.close()
+            newurl = wh.geturl()
         except HTTPError as e:
             wh = e        
+            if wh.getcode() >= 300 and wh.getcode() < 400:
+                newurl = wh.headers['Location']
+            else:
+                newurl = wh.geturl()
 
-        u = wh.geturl()
-        if u == url:
+        if newurl == url:
+            print (wh)
+            print (wh.geturl())
+            print (type(wh))
             # we didn't redirect
             raise ValidatorError('redirect', u, '{}/info.json'.format(url), result, 'Failed to redirect from {} to {}/info.json. Response code {}'.format(u, url, wh.getcode()))
         else:


### PR DESCRIPTION
It seems with python 2 it returns an error rather than following the redirect. This change checks the return code and if it is a redirect it sets the URL to check to Location