### PR TITLE
Catching error if there are problems with the image

### DIFF
--- a/iiif_validator/tests/region_pixels.py
+++ b/iiif_validator/tests/region_pixels.py
@@ -31,6 +31,6 @@ class Test_Region_Pixels(BaseTest):
                 return result
             else:
                 raise ValidatorError('color', 1,0, result)
-        except:
+        except Exception as error:
             self.validationInfo.check('status', result.last_status, 200, result)
-            raise
+            raise ValidatorError('General error', str(error), 'No error', result,'Failed to check size due to: {}'.format(error))

--- a/iiif_validator/tests/size_ch.py
+++ b/iiif_validator/tests/size_ch.py
@@ -35,6 +35,6 @@ class Test_Size_Ch(BaseTest):
                 return result
             else:
                 raise ValidatorError('color', 1,0, result)           
-        except:
+        except Exception as error:
             self.validationInfo.check('status', result.last_status, 200, result)
-            raise
+            raise ValidatorError('General error', str(error), 'No error', result,'Failed to check size due to: {}'.format(error))

--- a/iiif_validator/tests/size_percent.py
+++ b/iiif_validator/tests/size_percent.py
@@ -35,6 +35,7 @@ class Test_Size_Percent(BaseTest):
             else:
                 raise ValidatorError('color', 1,0, result) 
            
-        except:
+        except Exception as error:
             self.validationInfo.check('status', result.last_status, 200, result)
-            raise
+
+            raise ValidatorError('General error', str(error), 'No error', result,'Failed to check size due to: {}'.format(error))

--- a/iiif_validator/tests/size_region.py
+++ b/iiif_validator/tests/size_region.py
@@ -29,6 +29,5 @@ class Test_Size_Region(BaseTest):
                 if not ok:
                     raise ValidatorError('color', 1, self.validationInfo.colorInfo[0][0], result)
             return result
-        except:
-            self.validationInfo.check('status', result.last_status, 200, result)
-            raise
+        except Exception as error:
+            raise ValidatorError('General error', str(error), 'No error', result,'Failed to check size due to: {}'.format(error))

--- a/iiif_validator/tests/size_wc.py
+++ b/iiif_validator/tests/size_wc.py
@@ -13,6 +13,7 @@ class Test_Size_Wc(BaseTest):
             s = random.randint(450,750)
             params = {'size': '%s,' % s}
             img = result.get_image(params)
+            self.validationInfo.check('status', result.last_status, 200, result)
             self.validationInfo.check('size', img.size, (s,s), result)
 
             # Find square size
@@ -34,6 +35,5 @@ class Test_Size_Wc(BaseTest):
                 return result
             else:
                 raise ValidatorError('color', 1,0, result)          
-        except:
-            self.validationInfo.check('status', result.last_status, 200, result)
-            raise
+        except Exception as error:
+            raise ValidatorError('General error', str(error), 'No error', result,'Failed to check size due to: {}'.format(error))


### PR DESCRIPTION
Related to: https://github.com/IIIF/image-validator/issues/87. I'm not sure why the image is failing to build but this fix at least shows the error rather than returning a `500` error. 