### PR TITLE
Fix JP2/WEBP detection, Link header, CORS origin

### DIFF
--- a/iiif_validator/tests/cors.py
+++ b/iiif_validator/tests/cors.py
@@ -1,4 +1,4 @@
-from .test import BaseTest
+from .test import BaseTest, ValidatorError
 
 class Test_Cors(BaseTest):
     label = 'Cross Origin Headers'
@@ -14,5 +14,6 @@ class Test_Cors(BaseTest):
             if k.lower() == 'access-control-allow-origin':
                 cors = v
                 break
-        self.validationInfo.check('CORS', cors, '*', result, 'Failed to get correct CORS header.')
+        if cors != '*' and cors != result.get_request_origin():
+            raise ValidatorError('cors', cors, '*', result, 'Failed to match Access-Control-Allow-Origin response header')
         return result

--- a/iiif_validator/tests/format_jp2.py
+++ b/iiif_validator/tests/format_jp2.py
@@ -30,12 +30,10 @@ class Test_Format_Jp2(BaseTest):
         if wh.getcode() != 200:
             raise ValidatorError('format', 'http response code: {}'.format(wh.getcode()), url, result, 'Failed to retrieve jp2, got response code {}'.format(wh.getcode()))
 
-        with magic.Magic() as m:
-            print ('test')
-            info = m.id_buffer(img)
-            if not info.startswith('JPEG 2000'):
-                # Not JP2
-                raise ValidatorError('format', info, 'JPEG 2000', result)
-            else:
-                result.tests.append('format')
-                return result
+        info = magic.from_buffer(img[:1024])
+        if not info.startswith('JPEG 2000'):
+            # Not JP2
+            raise ValidatorError('format', info, 'JPEG 2000', result)
+        else:
+            result.tests.append('format')
+            return result

--- a/iiif_validator/tests/format_webp.py
+++ b/iiif_validator/tests/format_webp.py
@@ -25,7 +25,7 @@ class Test_Format_Webp(BaseTest):
             raise ValidatorError('format', 'http response code: {}'.format(error.code), url, result, 'Failed to retrieve webp, got response code {}'.format(error.code))
         img = wh.read()
         wh.close()
-        if img[8:12] != "WEBP":
+        if img[8:12] != b'WEBP':
             raise ValidatorError('format', 'unknown', 'WEBP', result)
         else:
             result.tests.append('format')

--- a/iiif_validator/validator.py
+++ b/iiif_validator/validator.py
@@ -255,9 +255,12 @@ class ImageAPI(object):
                 return uri
         return None
 
+    def get_request_origin(self):
+        return "http://iiif.io"
+
     def fetch(self, url):
         # Make it look like a real browser request
-        HEADERS = {"Origin": "http://iiif.io",
+        HEADERS = {"Origin": self.get_request_origin(),
             "Referer": "http://iiif.io/api/image/validator",
             "User-Agent": "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.1b3pre) Gecko/20081130 Minefield/3.1b3pre"}
         req = Request(url, headers=HEADERS)

--- a/iiif_validator/validator.py
+++ b/iiif_validator/validator.py
@@ -178,12 +178,10 @@ class ImageAPI(object):
             elif state == "uri":
                 uri = []
                 d = data.pop(0)                
-                while d != ";":
+                while d != ">":
                     uri.append(d)
                     d = data.pop(0)
                 uri = ''.join(uri)
-                uri = uri[:-1]
-                data.insert(0, ';')
                 # Not an error to have the same URI multiple times (I think!)
                 if (uri not in links):
                     links[uri] = {}

--- a/iiif_validator/validator.py
+++ b/iiif_validator/validator.py
@@ -257,7 +257,7 @@ class ImageAPI(object):
 
     def fetch(self, url):
         # Make it look like a real browser request
-        HEADERS = {"Origin": "http://iiif.io/", 
+        HEADERS = {"Origin": "http://iiif.io",
             "Referer": "http://iiif.io/api/image/validator",
             "User-Agent": "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en-US; rv:1.9.1b3pre) Gecko/20081130 Minefield/3.1b3pre"}
         req = Request(url, headers=HEADERS)


### PR DESCRIPTION
Hi - I ran into a few errors when running this - both locally and from iiif.io, so I wanted to propose changes from my findings. It's not clear to me if this repository is still maintained so kept them in a single PR for my own simplicity, but can resubmit to split them up for acceptance or discussion if you prefer.

More technical details are documented in the commit messages, so, to summarize:

* WEBP format (bug fix) - correctly identify magic header, seemingly related to a Python3 upgrade (previously the test result was a false negative)
* JP2 format (bug fix) - correctly invoke magic library, unsure the cause of this regression (previously it was an uncaught exception)
* Link header (bug fix) - allow semicolons in URIs (previously it was an uncaught exception)
* CORS (behavior change) - expanded support to accept origin-specific response headers (i.e. `http://iiif.io`) instead of only a wildcard (previously this case was unsupported)

Also, I'm not too sure about the testing practices for discovering if I'm breaking any expectations or simply misunderstood an expected failure. I'd be happy to amend this for test coverage after more guidance.

I would appreciate any feedback you might have on the changes - thanks!